### PR TITLE
fix npm install link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The temporary database is dropped after each debug.
 
 ## Install
 ```
-npm install mongo-aggregate-debugger
+npm install mongo-aggregation-debugger
 ```
 
 ## Instantiation


### PR DESCRIPTION
noticed that `npm install mongo-aggregate-debugger` returns 404 from npm registry when trying to install for a project. (should be aggregat-_ion_ debugger)
